### PR TITLE
[Bug] Fix #6 - ValueError: non-broadcastable output operand with shape () doesn't match the broadcast shape

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -18,4 +18,5 @@ exclude =
     # This contains builds of flake8 that we don't want to check
     dist,
     __init__.py,
+    tmp,
 max-complexity = 13

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+tmp/

--- a/openweb/thematic/clusters.py
+++ b/openweb/thematic/clusters.py
@@ -1,6 +1,7 @@
 """
 Module to do multi-resolution clustering.
 """
+import logging
 from typing import Iterable, List, cast
 
 import numpy as np
@@ -47,11 +48,13 @@ class MultiResCommunityDetection:
     def __init__(
         self,
         params: Iterable[dict],
+        logger: logging.Logger = logging.getLogger(__name__),
     ):
-        self._params = params
+        self._params = list(params)
         self._factory = FastCommunityDetection
         self.labels_: np.ndarray = np.array([])
         self.cluster_centers_: np.ndarray = np.ndarray([])
+        self._logger = logger
 
     def fit(
         self,
@@ -60,19 +63,29 @@ class MultiResCommunityDetection:
     ) -> "MultiResCommunityDetection":
         self.labels_ = np.repeat(-1, len(X))
         cluster_centers = cast(List[int], [])
-        mutable_x = X
+        mutable_x = np.array(X)
         indices = np.array(range(len(X)))
         cluster_cnt = 0
-        for kwargs in self._params:
+        for idx, kwargs in enumerate(self._params):
+            if len(mutable_x) == 0:
+                self._logger.info("all items has been assigned to a cluster")
+                break
+
             model = self._factory(**kwargs)
+            self._logger.info("created model #%s: %s", idx, kwargs)
+
             labels = model.fit_predict(mutable_x)
-            cluster_centers += model.cluster_centers_
+            centers = model.cluster_centers_.tolist()
+            self._logger.info("found %s clusters", len(centers))
+
+            cluster_centers += centers
+            np.put(
+                self.labels_,
+                ind=indices[np.argwhere(labels >= 0).reshape(-1)],
+                v=labels[labels >= 0] + cluster_cnt,
+            )
             cluster_cnt += max(labels) + 1
             mutable_x = mutable_x[labels < 0]
             indices = indices[labels < 0]
-            np.put(
-                self.labels_,
-                ind=indices[np.argwhere(labels > 0).reshape(-1)],
-                v=labels[labels > 0] + cluster_cnt,
-            )
+        self.cluster_centers_ = np.array(cluster_centers)
         return self

--- a/openweb/thematic/clusters_test.py
+++ b/openweb/thematic/clusters_test.py
@@ -1,3 +1,51 @@
+import collections
+from typing import Tuple
+
+import numpy as np
+import pytest
+from sklearn.datasets import make_blobs
+
+from openweb.thematic.clusters import MultiResCommunityDetection
+
+
+@pytest.fixture
+def mocked_data() -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    return make_blobs(  # type: ignore
+        n_samples=1000,
+        centers=25,
+        cluster_std=1,
+        n_features=100,
+        random_state=42,
+        return_centers=True,
+    )
+
+
+def test_MultiResCommunityDetection(
+    mocked_data: Tuple[np.ndarray, np.ndarray, np.ndarray]
+):
+    """
+    Trivial test on the clustering on a symmetrical dataset.
+    """
+    params = [
+        {
+            "threshold": 0.95,
+            "min_community_size": 15,
+            "init_max_size": 1000,
+        }
+    ]
+    X, _y, centers = mocked_data
+    model = MultiResCommunityDetection(params).fit(X)
+
+    assert len(model.cluster_centers_) == len(centers), "same number of clusters found"
+    assert (
+        max(model.labels_) == len(model.cluster_centers_) - 1
+    ), "id of clusters should not be more than number of clusters"
+
+    assert collections.Counter(model.labels_) == collections.Counter(
+        _y
+    ), "each cluster should have the same number of items"
+
+
 def test_normalize_params():
 
     ...

--- a/poetry.lock
+++ b/poetry.lock
@@ -646,7 +646,7 @@ name = "joblib"
 version = "1.1.0"
 description = "Lightweight pipelining with Python functions"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 
 [[package]]
@@ -1105,7 +1105,7 @@ name = "numpy"
 version = "1.21.5"
 description = "NumPy is the fundamental package for array computing with Python."
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7,<3.11"
 
 [[package]]
@@ -1591,7 +1591,7 @@ name = "scikit-learn"
 version = "1.0.2"
 description = "A set of python modules for machine learning and data mining"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -1611,7 +1611,7 @@ name = "scipy"
 version = "1.7.3"
 description = "SciPy: Scientific Library for Python"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.7,<3.11"
 
 [package.dependencies]
@@ -1728,7 +1728,7 @@ name = "threadpoolctl"
 version = "3.1.0"
 description = "threadpoolctl"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.6"
 
 [[package]]
@@ -1995,7 +1995,7 @@ torch = ["torch"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<3.11"
-content-hash = "a898f91c500b96579cb57d17467bdd3029e2edddb25940850870bcbfc3991026"
+content-hash = "dace4d070b4fbcee001086b9f9a5a1b705a1ed1373a9ff0d5f576c4ccce7bf6d"
 
 [metadata.files]
 appnope = [

--- a/pylintrc
+++ b/pylintrc
@@ -12,7 +12,7 @@ ignore=third_party
 
 # Files or directories matching the regex patterns are skipped. The regex
 # matches against base names, not paths.
-ignore-patterns=__init__
+ignore-patterns=__init__,.*test*
 
 # Pickle collected data for later comparisons.
 persistent=no

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ markdown_include = "*"
 isort = "5.*"
 livereload = "2.*"  # see https://github.com/mkdocstrings/mkdocstrings/issues/295
 jupyter = "^1.0.0"
+scikit-learn = "*"
 
 [tool.isort]
 profile = "black"
@@ -80,6 +81,7 @@ line_length = 88
 
 [tool.mypy]
 python_version = "3.7"
+plugins = "numpy.typing.mypy_plugin"
 warn_return_any = true
 warn_unused_configs = true
 exclude = [
@@ -95,12 +97,11 @@ exclude = [
 # module = "mycode.bar"
 # warn_return_any = false
 
-# [[tool.mypy.overrides]]
-# module = [
-#     "somelibrary",
-#     "some_other_library"
-# ]
-# ignore_missing_imports = true
+[[tool.mypy.overrides]]
+module = [
+    "sklearn.datasets",
+]
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 minversion = "6.0"


### PR DESCRIPTION
Fix a lot of bugs:
- incorrect typing for cluster centers
- incorrect order in updating the cluster id

See #6 

